### PR TITLE
Patch ctr-cryptotool for modern OpenSSL

### DIFF
--- a/ctr-cryptotool/README.md
+++ b/ctr-cryptotool/README.md
@@ -1,5 +1,7 @@
 ctr-cryptotool: 3DS tool for AES crypto. This includes a software implementation of the 3DS AES engine key-generator.
 
+Build with `gcc ctr-cryptotool.c -lcrypto -o ctr-cryptotool` (requires libcrypto, part of openssl)
+
 ctrclient.* and utils.* are based on the code from {neimod/ctr repo}/ctr/ramtracer/ctrclient. When ctrclient apps are built with CTRCLIENT={path to this ctr-cryptotool directory}, this allows the app to use the ctrclient API for doing local AES crypto using the sw implementation of the key-generator(and regular normal-keys too). When the required keys are not all set, this will fallback to sending network commands for crypto. When building ctrclient apps with this, add this make command-line option: "LIBS=-lcrypto".
 
 This also requires a config file @ "$HOME/.3ds/aeskeyslots_keys", each text line has the following structure: {hex value for the keyslot} {key params}. Where key params can be any of the following: "normalkey=hex", "keyX=hex", or "keyY=hex". If this file doesn't exist or no keys are set here, then local crypto will not be used except when regular normal-keys are set via the ctrclient API. See source for more details for config handling.

--- a/ctr-cryptotool/ctr-cryptotool.c
+++ b/ctr-cryptotool/ctr-cryptotool.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 
 #include <openssl/aes.h>
+#include <openssl/modes.h>
 
 //Build with: gcc ctr-cryptotool.c -lcrypto -o ctr-cryptotool
 
@@ -947,7 +948,7 @@ int main(int argc, char *argv[])
        	 			return 1;
     			}
 
-			AES_ctr128_encrypt(buffer, buffer, inbufsize, &aeskey, ctr, aes_ecount, &aes_num);
+			CRYPTO_ctr128_encrypt(buffer, buffer, inbufsize, &aeskey, ctr, aes_ecount, &aes_num, (block128_f)AES_encrypt);
 		}
 		else if(cryptmode==4)
 		{
@@ -1071,7 +1072,7 @@ int main(int argc, char *argv[])
        			 			return 1;
     					}
 
-					AES_ctr128_encrypt(buffer, buffer, 0x10, &aeskey, ctr, aes_ecount, &aes_num);
+					CRYPTO_ctr128_encrypt(buffer, buffer, 0x10, &aeskey, ctr, aes_ecount, &aes_num, (block128_f)AES_encrypt);
 				}
 				else
 				{

--- a/ctr-cryptotool/ctrclient.c
+++ b/ctr-cryptotool/ctrclient.c
@@ -18,6 +18,7 @@
 #endif
 
 #include <openssl/aes.h>
+#include <openssl/modes.h>
 
 #include <stdint.h>
 
@@ -661,7 +662,7 @@ int ctrclient_aes_ctr_crypt(ctrclient* client, unsigned char* buffer, unsigned i
 
 	while(pos < size)
 	{
-		AES_ctr128_encrypt(&buffer[pos], &buffer[pos], 0x10, &aeskey_enc, current_aesctr, aes_ecount, &aes_num);
+		CRYPTO_ctr128_encrypt(&buffer[pos], &buffer[pos], 0x10, &aeskey_enc, current_aesctr, aes_ecount, &aes_num, (block128_f)AES_encrypt);
 		pos+= 0x10;
 	}
 


### PR DESCRIPTION
Modifies ctr-cryptotool such that it will build with modern versions of OpenSSL, which have removed the `AES_ctr128_encrypt` function, by adapting it to use `CRYPTO_ctr128_encrypt` instead.

Also adds a note to the README.md file with build instructions, since naive users might not read the source files and thereby miss the comment there.

Signed-off-by: Lauren Kelly <lauren.kelly@msn.com>